### PR TITLE
Update oprettelse.md

### DIFF
--- a/docs/slutbruger/opstart/oprettelse.md
+++ b/docs/slutbruger/opstart/oprettelse.md
@@ -7,27 +7,27 @@ nav_order: 1
 
 # **Sådan bliver du oprettet som bruger**
 
-Det eneste der kræves for at blive oprettet som bruger af OS2samtale er at sende en mail til   
+Det eneste, det kræver at blive oprettet som bruger af OS2samtale, er at sende en mail til   
 [https://os2samtale.os2.eu/](https://os2samtale.os2.eu/), hvor du skriver:
 
-- Hvem du er og hvilken organisation du kommer fra
-- din email addresse
-- Hvilke OS2 produkter du er interesseret i at følge
-- Hvilke produkter du evt er styregruppe- eller koordinationsgruppe medlem i 
+- Hvem du er, og hvilken organisation du kommer fra
+- Din e-mailaddresse
+- Hvilke OS2-produkter, du er interesseret i at følge
+- Hvilken rolle, du evt. har i pågældende produkter (eksempelvis styre-, koordinations-, projektgruppemedlem, produktkoordinator, kontaktperson, community manager osv.)
 
-Som leverandør skal du bede produktkoordinatoren for det produkt du er tilknyttet om at sørge for at du bliver oprettet som gæstebruger.   
+Som leverandør skal du bede produktkoordinatoren for det produkt, du er tilknyttet, om at sørge for, at du bliver oprettet som gæstebruger.   
 
-# sådan behandles din anmodning
+# Sådan behandles din anmodning
 
-Når du har sendt en anmodning om at blive oprettet som bruger af OS2samtale vil support og administratorfunktionen:
--  oprette dig i systemet, med navn og email
--  generere et kodeord til dig, 
--  Give besked til Kanal moderatorerne om at du skal tilknyttes de  nævnte Kanaler
--  sende dig en mail med sikkert link til dit kodeord.
+Når du har sendt en anmodning om at blive oprettet som bruger af OS2samtale, vil support- og administratorfunktionen:
+-  Oprette dig i systemet, med navn og e-mail
+-  Generere et kodeord til dig 
+-  Give besked til kanalmoderatorerne om, at du skal tilknyttes de pågældende kanaler
+-  Sende dig en e-mail med sikkert link til dit kodeord
 
-NB! Administratorer har ikke mulighed for at se dit kodeord igen efter at det er sendt til dig.
+NB! Administratorer har ikke mulighed for at se dit kodeord, efter at det er sendt til dig.
 
-Hvis du ønsker det kan du herefter gå ind og ændre dit kodeord i Authentic - se "skift kodeord" for detaljer.
+Hvis du ønsker det kan du herefter selv ændre dit kodeord i Authentik (identitet- og adgangsstyringssystem) - se *skift kodeord*
 
 ***
 


### PR DESCRIPTION
Korrektur og formulering.

# Forslag: Opret et afsnit med titlen *hvem kan få adgang til OS2samtale?*

Her uddybets kort hvem der kan få adgang - og hvem der ikke kan. 

Argument for at tilføje dette afsnit er dels for at indikere (både til OS2'ere og andre), at det ikke er en fuldstændig åben platform - for at afbøde eventuelle 'chok', hvis en forespørgsel om brugeroprettelse afvises. Derudover markeres det også, at man er velkommen til at spørge, hvis man bliver i tvivl. 
Man kan forestille sig, at nogle deltagere vil have en bekymring om, hvorvidt 'alle bare bliver lukket ind'. Her indikerer afsnittet også, at nej, det gør de ikke nødvendigvis. 

Fx: 

_OS2samtale er et værktøj OS2 anvender til intern kommunikation for bidragsydere og forskellige samarbejdspartnere. 

Har du ingen tilknytning til OS2 eller et OS2-produkt, er OS2samtale ikke relevant for dig. 

Er du i tvivl om, hvorvidt det giver mening for dig, at have adgang til intern kommunikation i OS2samtale, kan du kontakte support via os2samtale@os2.eu_ 